### PR TITLE
docs(test-assertions): optimize custom matcher to handle negative assertions efficiently

### DIFF
--- a/docs/src/test-assertions-js.md
+++ b/docs/src/test-assertions-js.md
@@ -258,7 +258,7 @@ In this example we add a custom `toHaveAmount` function. Custom matcher should r
 
 ```js title="fixtures.ts"
 import { expect as baseExpect } from '@playwright/test';
-import type { Page, Locator } from '@playwright/test';
+import type { Locator } from '@playwright/test';
 
 export { test } from '@playwright/test';
 
@@ -268,11 +268,16 @@ export const expect = baseExpect.extend({
     let pass: boolean;
     let matcherResult: any;
     try {
-      await baseExpect(locator).toHaveAttribute('data-amount', String(expected), options);
+      const expectation = this.isNot ? baseExpect(locator).not : baseExpect(locator);
+      await expectation.toHaveAttribute('data-amount', String(expected), options);
       pass = true;
     } catch (e: any) {
       matcherResult = e.matcherResult;
       pass = false;
+    }
+
+    if (this.isNot) {
+      pass =!pass;
     }
 
     const message = pass

--- a/tests/playwright-test/expect.spec.ts
+++ b/tests/playwright-test/expect.spec.ts
@@ -762,11 +762,16 @@ test('should chain expect matchers and expose matcher utils (TSC)', async ({ run
         let pass: boolean;
         let matcherResult: any;
         try {
-          await baseExpect(baseAmount).toHaveAttribute('data-amount', expected, options);
+          const expectation = this.isNot ? baseExpect(baseAmount).not : baseExpect(baseAmount);
+          await expectation.toHaveAttribute('data-amount', expected, options);
           pass = true;
         } catch (e: any) {
           matcherResult = e.matcherResult;
           pass = false;
+        }
+
+        if (this.isNot) {
+            pass = !pass;
         }
 
         const expectOptions = {
@@ -842,11 +847,16 @@ test('should chain expect matchers and expose matcher utils', async ({ runInline
         let pass: boolean;
         let matcherResult: any;
         try {
-          await baseExpect(baseAmount).toHaveAttribute('data-amount', expected, options);
+          const expectation = this.isNot ? baseExpect(baseAmount).not : baseExpect(baseAmount);
+          await expectation.toHaveAttribute('data-amount', expected, options);
           pass = true;
         } catch (e: any) {
           matcherResult = e.matcherResult;
           pass = false;
+        }
+
+        if (this.isNot) {
+            pass = !pass;
         }
 
         const expectOptions = {
@@ -888,7 +898,7 @@ test('should chain expect matchers and expose matcher utils', async ({ runInline
   }, { workers: 1 });
   const output = stripAnsi(result.output);
   expect(output).toContain(`await expect(page.locator('div')).toHaveAmount('3', { timeout: 1000 });`);
-  expect(output).toContain('a.spec.ts:60');
+  expect(output).toContain('a.spec.ts:65');
   expect(result.failed).toBe(1);
   expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
Updated documentation and tests to improve performance and eliminate false 'failed' assertions in the UI, even when tests pass.
In this PR https://github.com/Marcin3/challenge/pull/8, I compared the old and new solutions:

- Old version: Took the full timeout (5 seconds) and was incorrectly marked as failed ("red") in the UI:

![image](https://github.com/user-attachments/assets/cb286c93-b277-49d6-80ff-2e5089633483)

- New version: Completed in just 655 ms and is correctly marked as passed:

![image](https://github.com/user-attachments/assets/6187bd21-842a-4f9a-b8bb-68326b344f24)
I also updated the method used in the test to align with the new documentation.
References https://github.com/microsoft/playwright/issues/34390